### PR TITLE
Feature/26 card add event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7533,6 +7533,14 @@
         }
       }
     },
+    "sass": {
+      "version": "1.26.10",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.10.tgz",
+      "integrity": "sha512-bzN0uvmzfsTvjz0qwccN1sPm2HxxpNI/Xa+7PlUEMS+nQvbyuEK7Y0qFqxlPHhiNHb1Ze8WQJtU31olMObkAMw==",
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
+    },
     "sass-loader": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-9.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "nodemon": "^2.0.4",
     "npm-run-all": "^4.1.5",
     "pug": "2.0.0-beta11",
+    "sass": "^1.26.10",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"
   },

--- a/public/javascripts/components/Card.js
+++ b/public/javascripts/components/Card.js
@@ -1,1 +1,43 @@
+import { templateToElement } from '../utils/HtmlGenerator'
 import '../../stylesheets/components/card.scss'
+
+export default class Card {
+  constructor(cardTitle) {
+    this.cardTitle = cardTitle
+    this.user = 'choibumsu'
+    this.$target = ''
+
+    this.init()
+  }
+
+  init() {
+    this.setElements()
+    this.bindEvent()
+  }
+
+  setElements() {
+    const template = `
+      <div class='card'>
+        <img class='document-icon' src='/static/images/document.svg') />
+        <div class='content-container'>
+          <div class='content-wrapper'>
+            <div class='title'>${this.cardTitle}</div>
+            <div class='added-by'>
+              <span>Added by </span>
+              <span class='strong'>${this.user}</span>
+            </div>
+          </div>
+          <img class='remove-icon' src='/static/images/remove-btn.svg' />
+          </div>
+      </div>
+    `
+
+    this.$target = templateToElement(template)
+  }
+
+  getTarget() {
+    return this.$target
+  }
+
+  bindEvent() {}
+}

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -1,18 +1,21 @@
 import { templateToElement } from '../utils/HtmlGenerator'
+import { CLASS_NAME } from '../utils/Constants'
 import '../../stylesheets/components/cardForm.scss'
 
 export default class CardForm {
   constructor() {
     this.$target = ''
+    this.$cardTextarea = ''
 
     this.init()
   }
 
   init() {
-    this.setTarget()
+    this.setElements()
+    this.bindEvent()
   }
 
-  setTarget() {
+  setElements() {
     const template = `
       <div class='card-form'>
         <textarea class='card-textarea' placeholder='Enter a note' maxlength='500'></textarea>
@@ -28,5 +31,22 @@ export default class CardForm {
     `
 
     this.$target = templateToElement(template)
+    this.$cardTextarea = this.$target.querySelector('textarea.card-textarea')
+    this.$addBtn = this.$target.querySelector('.add-btn')
+  }
+
+  bindEvent() {
+    this.$cardTextarea.addEventListener('input', (e) => {
+      this.setActiveAddbtn(e)
+    })
+  }
+
+  setActiveAddbtn(e) {
+    if (e.target.value) {
+      this.$addBtn.classList.remove(CLASS_NAME.UNACTIVE)
+      return
+    }
+
+    this.$addBtn.classList.add(CLASS_NAME.UNACTIVE)
   }
 }

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -33,11 +33,16 @@ export default class CardForm {
     this.$target = templateToElement(template)
     this.$cardTextarea = this.$target.querySelector('textarea.card-textarea')
     this.$addBtn = this.$target.querySelector('.add-btn')
+    this.$cancelBtn = this.$target.querySelector('.cancel-btn')
   }
 
   bindEvent() {
     this.$cardTextarea.addEventListener('input', (e) => {
       this.setActiveAddbtn(e)
+    })
+
+    this.$cancelBtn.addEventListener('click', (e) => {
+      this.removeCardForm()
     })
   }
 
@@ -48,5 +53,9 @@ export default class CardForm {
     }
 
     this.$addBtn.classList.add(CLASS_NAME.UNACTIVE)
+  }
+
+  removeCardForm() {
+    this.$target.remove()
   }
 }

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -1,6 +1,7 @@
 import { templateToElement } from '../utils/HtmlGenerator'
 import { CLASS_NAME, CARD_FORM_CLASS, COLUMN_CLASS } from '../utils/Constants'
 import '../../stylesheets/components/cardForm.scss'
+import Card from './Card'
 
 export default class CardForm {
   constructor() {
@@ -8,6 +9,7 @@ export default class CardForm {
     this.$cardTextarea = ''
     this.$addBtn = ''
     this.$cancelBtn = ''
+    this.isActive = false
 
     this.init()
   }
@@ -44,7 +46,7 @@ export default class CardForm {
 
   bindEvent() {
     this.$cardTextarea.addEventListener('input', (e) => {
-      this.setActiveAddbtn(e)
+      this.setActive(e.target.value)
     })
 
     this.$cancelBtn.addEventListener('click', (e) => {
@@ -56,8 +58,10 @@ export default class CardForm {
     })
   }
 
-  setActiveAddbtn(e) {
-    if (e.target.value) {
+  setActive(isActive) {
+    this.isActive = isActive
+
+    if (this.isActive) {
       this.$addBtn.classList.remove(CLASS_NAME.UNACTIVE)
       return
     }
@@ -70,10 +74,18 @@ export default class CardForm {
   }
 
   addCard() {
+    if (!this.isActive) {
+      return
+    }
+
     const $parentColumn = this.$target.closest('.column')
     const $contentContainer = $parentColumn.querySelector(
       `.${COLUMN_CLASS.CONTENT_CONTAINER}`
     )
-    $contentContainer.innerHTML = `${this.$cardTextarea.value}`
+    const $newCard = new Card(this.$cardTextarea.value).getTarget()
+    $contentContainer.appendChild($newCard)
+
+    this.$cardTextarea.value = ''
+    this.setActive(false)
   }
 }

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -1,5 +1,5 @@
 import { templateToElement } from '../utils/HtmlGenerator'
-import { CLASS_NAME, CARD_FORM_CLASS } from '../utils/Constants'
+import { CLASS_NAME, CARD_FORM_CLASS, COLUMN_CLASS } from '../utils/Constants'
 import '../../stylesheets/components/cardForm.scss'
 
 export default class CardForm {
@@ -50,6 +50,10 @@ export default class CardForm {
     this.$cancelBtn.addEventListener('click', (e) => {
       this.removeCardForm()
     })
+
+    this.$addBtn.addEventListener('click', (e) => {
+      this.addCard()
+    })
   }
 
   setActiveAddbtn(e) {
@@ -63,5 +67,13 @@ export default class CardForm {
 
   removeCardForm() {
     this.$target.remove()
+  }
+
+  addCard() {
+    const $parentColumn = this.$target.closest('.column')
+    const $contentContainer = $parentColumn.querySelector(
+      `.${COLUMN_CLASS.CONTENT_CONTAINER}`
+    )
+    $contentContainer.innerHTML = `${this.$cardTextarea.value}`
   }
 }

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -1,11 +1,13 @@
 import { templateToElement } from '../utils/HtmlGenerator'
-import { CLASS_NAME } from '../utils/Constants'
+import { CLASS_NAME, CARD_FORM_CLASS } from '../utils/Constants'
 import '../../stylesheets/components/cardForm.scss'
 
 export default class CardForm {
   constructor() {
     this.$target = ''
     this.$cardTextarea = ''
+    this.$addBtn = ''
+    this.$cancelBtn = ''
 
     this.init()
   }
@@ -31,9 +33,13 @@ export default class CardForm {
     `
 
     this.$target = templateToElement(template)
-    this.$cardTextarea = this.$target.querySelector('textarea.card-textarea')
-    this.$addBtn = this.$target.querySelector('.add-btn')
-    this.$cancelBtn = this.$target.querySelector('.cancel-btn')
+    this.$cardTextarea = this.$target.querySelector(
+      `.${CARD_FORM_CLASS.TEXTAREA}`
+    )
+    this.$addBtn = this.$target.querySelector(`.${CARD_FORM_CLASS.ADD_BTN}`)
+    this.$cancelBtn = this.$target.querySelector(
+      `.${CARD_FORM_CLASS.CANCEL_BTN}`
+    )
   }
 
   bindEvent() {

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -1,1 +1,32 @@
+import { templateToElement } from '../utils/HtmlGenerator'
 import '../../stylesheets/components/cardForm.scss'
+
+export default class CardForm {
+  constructor() {
+    this.$target = ''
+
+    this.init()
+  }
+
+  init() {
+    this.setTarget()
+  }
+
+  setTarget() {
+    const template = `
+      <div class='card-form'>
+        <textarea class='card-textarea' placeholder='Enter a note' maxlength='500'></textarea>
+        <div class='button-row'>
+          <div class='btn-wrapper'>
+            <div class='btn add-btn unactive'>Add</div>
+          </div>
+          <div class='btn-wrapper'>
+            <div class='btn cancel-btn'>Cancel</div>
+          </div>
+        </div>
+      </div>
+    `
+
+    this.$target = templateToElement(template)
+  }
+}

--- a/public/javascripts/components/CardForm.js
+++ b/public/javascripts/components/CardForm.js
@@ -83,7 +83,7 @@ export default class CardForm {
       `.${COLUMN_CLASS.CONTENT_CONTAINER}`
     )
     const $newCard = new Card(this.$cardTextarea.value).getTarget()
-    $contentContainer.appendChild($newCard)
+    $contentContainer.prepend($newCard)
 
     this.$cardTextarea.value = ''
     this.setActive(false)

--- a/public/javascripts/components/Column.js
+++ b/public/javascripts/components/Column.js
@@ -1,3 +1,5 @@
+import { templateToElement } from '../utils/HtmlGenerator'
+import CardForm from './CardForm'
 import '../../stylesheets/components/column.scss'
 
 export default class Column {
@@ -13,6 +15,7 @@ export default class Column {
   init() {
     this.setTarget()
     this.render()
+    this.bindEvent()
   }
 
   setTarget() {
@@ -33,11 +36,31 @@ export default class Column {
       </section>
     `
 
-    this.$target = document.createRange().createContextualFragment(template)
+    this.$target = templateToElement(template)
+    console.log(this.$target)
   }
 
   render() {
     const parentElement = document.querySelector(this.parentSelector)
     parentElement.appendChild(this.$target)
+  }
+
+  bindEvent() {
+    const $cardAddBtn = this.$target.querySelector('.add-btn')
+    $cardAddBtn.addEventListener('click', () => {
+      this.toggleCardForm()
+    })
+  }
+
+  toggleCardForm() {
+    const cardFormSlot = this.$target.querySelector('.card-form-slot')
+
+    if (cardFormSlot.innerHTML) {
+      cardFormSlot.innerHTML = ''
+      return
+    }
+
+    const cardForm = new CardForm()
+    cardFormSlot.appendChild(cardForm.$target)
   }
 }

--- a/public/javascripts/components/Column.js
+++ b/public/javascripts/components/Column.js
@@ -1,10 +1,10 @@
 import { templateToElement } from '../utils/HtmlGenerator'
 import CardForm from './CardForm'
 import '../../stylesheets/components/column.scss'
+import { COLUMN_CLASS } from '../utils/Constants'
 
 export default class Column {
-  constructor({ parentSelector, columnTitle, cardCount }) {
-    this.parentSelector = parentSelector
+  constructor({ columnTitle, cardCount }) {
     this.columnTitle = columnTitle
     this.cardCount = cardCount
     this.$target = ''
@@ -40,26 +40,30 @@ export default class Column {
   }
 
   render() {
-    const parentElement = document.querySelector(this.parentSelector)
-    parentElement.appendChild(this.$target)
+    const $columnContainer = document.querySelector(
+      `.${COLUMN_CLASS.CONTAINER}`
+    )
+    $columnContainer.appendChild(this.$target)
   }
 
   bindEvent() {
-    const $cardAddBtn = this.$target.querySelector('.add-btn')
+    const $cardAddBtn = this.$target.querySelector(`.${COLUMN_CLASS.ADD_BTN}`)
     $cardAddBtn.addEventListener('click', () => {
       this.toggleCardForm()
     })
   }
 
   toggleCardForm() {
-    const cardFormSlot = this.$target.querySelector('.card-form-slot')
+    const $cardFormSlot = this.$target.querySelector(
+      `.${COLUMN_CLASS.CARD_FORM_SLOT}`
+    )
 
-    if (cardFormSlot.innerHTML) {
-      cardFormSlot.innerHTML = ''
+    if ($cardFormSlot.innerHTML) {
+      $cardFormSlot.innerHTML = ''
       return
     }
 
     const cardForm = new CardForm()
-    cardFormSlot.appendChild(cardForm.$target)
+    $cardFormSlot.appendChild(cardForm.$target)
   }
 }

--- a/public/javascripts/components/Column.js
+++ b/public/javascripts/components/Column.js
@@ -13,12 +13,12 @@ export default class Column {
   }
 
   init() {
-    this.setTarget()
+    this.setElements()
     this.render()
     this.bindEvent()
   }
 
-  setTarget() {
+  setElements() {
     const template = `
       <section class='column'>
         <div class='title-bar'>
@@ -37,7 +37,6 @@ export default class Column {
     `
 
     this.$target = templateToElement(template)
-    console.log(this.$target)
   }
 
   render() {

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -14,17 +14,17 @@ import '../stylesheets/common/base.scss'
 const tempColumns = [
   {
     parentSelector: '#column-container',
-    cardTitle: 'To Doooooo!',
+    columnTitle: 'To Doooooo!',
     cardCount: 3,
   },
   {
     parentSelector: '#column-container',
-    cardTitle: 'In Progess~',
+    columnTitle: 'In Progess~',
     cardCount: 3,
   },
   {
     parentSelector: '#column-container',
-    cardTitle: 'Done!!!',
+    columnTitle: 'Done!!!',
     cardCount: 3,
   },
 ]

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -11,19 +11,21 @@ import './components/LoginForm'
 import './components/SideBarCard'
 import '../stylesheets/common/base.scss'
 
+const columnContainerSelector = '#column-container'
+
 const tempColumns = [
   {
-    parentSelector: '#column-container',
+    parentSelector: columnContainerSelector,
     columnTitle: 'To Doooooo!',
     cardCount: 3,
   },
   {
-    parentSelector: '#column-container',
+    parentSelector: columnContainerSelector,
     columnTitle: 'In Progess~',
     cardCount: 3,
   },
   {
-    parentSelector: '#column-container',
+    parentSelector: columnContainerSelector,
     columnTitle: 'Done!!!',
     cardCount: 3,
   },

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -11,21 +11,16 @@ import './components/LoginForm'
 import './components/SideBarCard'
 import '../stylesheets/common/base.scss'
 
-const columnContainerSelector = '#column-container'
-
 const tempColumns = [
   {
-    parentSelector: columnContainerSelector,
     columnTitle: 'To Doooooo!',
     cardCount: 3,
   },
   {
-    parentSelector: columnContainerSelector,
     columnTitle: 'In Progess~',
     cardCount: 3,
   },
   {
-    parentSelector: columnContainerSelector,
     columnTitle: 'Done!!!',
     cardCount: 3,
   },

--- a/public/javascripts/utils/Constants.js
+++ b/public/javascripts/utils/Constants.js
@@ -2,3 +2,9 @@ export const CLASS_NAME = {
   DP_NONE: 'dp-none',
   UNACTIVE: 'unactive',
 }
+
+export const COLUMN_CLASS = {
+  CONTAINER: 'column-container',
+  ADD_BTN: 'add-btn',
+  CARD_FORM_SLOT: 'card-form-slot',
+}

--- a/public/javascripts/utils/Constants.js
+++ b/public/javascripts/utils/Constants.js
@@ -8,3 +8,9 @@ export const COLUMN_CLASS = {
   ADD_BTN: 'add-btn',
   CARD_FORM_SLOT: 'card-form-slot',
 }
+
+export const CARD_FORM_CLASS = {
+  TEXTAREA: 'card-textarea',
+  ADD_BTN: 'add-btn',
+  CANCEL_BTN: 'cancel-btn',
+}

--- a/public/javascripts/utils/Constants.js
+++ b/public/javascripts/utils/Constants.js
@@ -7,6 +7,7 @@ export const COLUMN_CLASS = {
   CONTAINER: 'column-container',
   ADD_BTN: 'add-btn',
   CARD_FORM_SLOT: 'card-form-slot',
+  CONTENT_CONTAINER: 'content-container',
 }
 
 export const CARD_FORM_CLASS = {

--- a/public/javascripts/utils/Constants.js
+++ b/public/javascripts/utils/Constants.js
@@ -1,3 +1,4 @@
 export const CLASS_NAME = {
   DP_NONE: 'dp-none',
+  UNACTIVE: 'unactive',
 }

--- a/public/javascripts/utils/HtmlGenerator.js
+++ b/public/javascripts/utils/HtmlGenerator.js
@@ -1,0 +1,5 @@
+export const templateToElement = (template) => {
+  const parser = new DOMParser()
+
+  return parser.parseFromString(template, 'text/html').body.firstElementChild
+}

--- a/public/stylesheets/components/cardForm.scss
+++ b/public/stylesheets/components/cardForm.scss
@@ -11,6 +11,7 @@
     min-width: 100%;
     max-width: 100%;
     min-height: 60px;
+    max-height: 500px;
     font-size: 14px;
     border: 1px solid $color-gray-300;
     border-radius: 6px;

--- a/public/stylesheets/components/cardForm.scss
+++ b/public/stylesheets/components/cardForm.scss
@@ -54,6 +54,7 @@
         }
         box-shadow: 0 1px 0 unquote($color-btn-border + '20'),
           inset 0 1px 0 hsla(0, 0%, 100%, 0.03);
+        cursor: pointer;
 
         &.add-btn {
           background-color: $color-green;

--- a/public/stylesheets/components/column.scss
+++ b/public/stylesheets/components/column.scss
@@ -89,6 +89,7 @@
     }
 
     > .content-container {
+      padding: 3px 0;
       overflow-y: scroll;
     }
   }

--- a/public/stylesheets/components/column.scss
+++ b/public/stylesheets/components/column.scss
@@ -1,6 +1,6 @@
 @import '../common/definitions';
 
-#column-container {
+.column-container {
   display: flex;
   height: calc(100vh - #{$height-nav});
   padding: 16px 0;

--- a/views/index.pug
+++ b/views/index.pug
@@ -13,5 +13,5 @@ html
         include ./DeleteCardModal.pug
         //- include ./EditCardModal.pug
         //- include ./EditColumnModal.pug
-        #column-container
+        .column-container
             include ./Column.pug


### PR DESCRIPTION
### Feature
- htmlGenerator.js : 문자열 리터럴을 인자로 받아, 이를 html element로 변환해주는 함수
- CardForm 컴포넌트 : 카드를 생성하기 위해 만들어지는 textarea와 버튼들을 갖는 컴포넌트
  - input 이벤트 : textarea에 값이 있으면 active, 없으면 unactive
  - cancel 버튼 click 이벤트 : 취소 버튼 클릭시, 해당 카드폼 컴포넌트 제거
  - add 버튼 click 이벤트 : 확인 버튼 클릭시, textarea의 내용을 제목으로 갖는 카드 컴포넌트 생성 및 컬럼에 삽입
- Column 컴포넌트
  - add 버튼 click 이벤트 : +버튼 클릭시, 카드폼 컴포넌트 생성. 만약 이미 있다면 제거

### Refactor
- 컴포넌트마다 내부에서 사용하는 클래스명들을 Constants.js 로 분리
- CardForm 컴포넌트에서 active 상태에 따른 버튼 css 변화, this.isActive를 한번에 관리하기 위해 setActive 메소드 구현

### Fix
- sass 패키지 다시 설치 : sass loader로 빌드가 가능한 줄 알았으나 sass 패키지가 필요했음
- 자잘한 오타 수정