### PR TITLE
[#79] fix(card) - 카드 아이디 중복되는 버그 해결

### DIFF
--- a/public/javascripts/components/Column.js
+++ b/public/javascripts/components/Column.js
@@ -146,8 +146,24 @@ export default class Column {
     if (cardTitle === '') return
 
     // api 호출 후 id 받기
+    // temp getNewId
+    const getNewId = () => {
+      return (
+        Array.from(document.querySelectorAll('.card')).reduce(
+          (maxId, $card) => {
+            const id = +$card.dataset.id
+            if (maxId < id) {
+              maxId = id
+            }
+            return maxId
+          },
+          0
+        ) + 1
+      )
+    }
+
     const cardData = {
-      id: 1,
+      id: getNewId(),
       title: cardTitle,
       username: 'choibumsu',
       nextCardId: this.getNewNextCardId(),


### PR DESCRIPTION
카드 아이디가 중복되어 이벤트가 꼬이는 현상 발생
api 작업을 하여 중복되지 않는 아이디를 받으면 해결되는 문제이나, 임시로 해결
문서에 존재하는 카드들의 아이디 중 가장 높은 아이디 + 1을 한 값을 새로운 카드 아이디로 줌