### PR TITLE
[#120] fix(card) - 스크롤 생길시 드래그 이벤트 위치가 이상해지는 버그 해결

### DIFF
--- a/public/javascripts/components/Card.js
+++ b/public/javascripts/components/Card.js
@@ -64,15 +64,27 @@ export default class Card {
 
   // 카드를 복사
   copyTarget(e) {
+    this.scrollLeft = document.querySelector(
+      `.${COLUMN_CLASS.CONTAINER}`
+    ).scrollLeft
+    this.scrollTop = this.$target.closest(
+      `.${COLUMN_CLASS.CONTENT_CONTAINER}`
+    ).scrollTop
+
+    const defaultGap = 10
     this.$copyTarget = this.$target.cloneNode(true)
-    this.$copyTarget.style.left = `${this.$target.offsetLeft + 10}px`
-    this.$copyTarget.style.top = `${this.$target.offsetTop - 10}px`
+    this.$copyTarget.style.left = `${
+      this.$target.offsetLeft - this.scrollLeft + defaultGap
+    }px`
+    this.$copyTarget.style.top = `${
+      this.$target.offsetTop - this.scrollTop - defaultGap
+    }px`
     this.$copyTarget.style.width = `${this.$target.offsetWidth}px`
     this.$copyTarget.classList.add(CARD_CLASS.COPY)
 
     this.offsetDiff = {
-      left: e.pageX - this.$target.offsetLeft - 10,
-      top: e.pageY - this.$target.offsetTop + 10,
+      left: e.pageX + this.scrollLeft - this.$target.offsetLeft - defaultGap,
+      top: e.pageY + this.scrollTop - this.$target.offsetTop + defaultGap,
     }
 
     document.body.appendChild(this.$copyTarget)

--- a/public/javascripts/components/Column.js
+++ b/public/javascripts/components/Column.js
@@ -183,8 +183,10 @@ export default class Column {
     const cardTitle = this.cardForm.getCardTitle()
     if (cardTitle === '') return
 
+    const nextCardId = this.getNewNextCardId()
     const [data, status] = await createCardApi({
       cardTitle,
+      nextCardId,
       columnId: this.id,
       userId: 1,
     })
@@ -194,7 +196,7 @@ export default class Column {
         id: data.id,
         title: cardTitle,
         username: 'choibumsu',
-        nextCardId: this.getNewNextCardId(),
+        nextCardId,
       }
 
       const newCard = new Card(cardData)


### PR DESCRIPTION
pageX, pageY는 루트 객체로부터의 좌표값이기 때문에 스크롤이 생겨도 스크롤을 포함한 값을 가짐
때문에 스크롤만큼의 좌표값을 빼줘야 현재 화면에서의 상대적인 좌표를 구할 수 있음
스크롤이 생기는 바깥쪽 container와 content-container의 스크롤값을 이용해 좌표를 수정